### PR TITLE
Fix missing server source error

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
+source 'https://rubygems.org'
+
 gem 'mutant', :git => 'https://github.com/mbj/mutant.git'
 gem 'mutant-rspec'
 gem 'rspec-expectations'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -22,6 +22,7 @@ GIT
       rspec-core (>= 3.3.0, < 3.5.0)
 
 GEM
+  remote: https://rubygems.org/
   specs:
     abstract_type (0.0.7)
     adamantium (0.2.0)
@@ -94,4 +95,4 @@ DEPENDENCIES
   rspec-mocks
 
 BUNDLED WITH
-   1.11.2
+   1.12.5


### PR DESCRIPTION
With Bundler 1.12.5, it was failing with:

```
Your Gemfile has no gem server sources. If you need gems that are not
already on your machine, add a line like this to your Gemfile:
source 'https://rubygems.org'
```